### PR TITLE
Send DTMF using SIP INFO

### DIFF
--- a/ios/RTCPjSip/PjSipCall.m
+++ b/ios/RTCPjSip/PjSipCall.m
@@ -133,10 +133,11 @@
 }
 
 - (void)dtmf:(NSString*) digits {
-    // TODO: Fallback for "The RFC 2833 payload format did not work".
-    
-    pj_str_t value = pj_str((char *) [digits UTF8String]);
-    pjsua_call_dial_dtmf(self.id, &value);
+    pjsua_call_send_dtmf_param param;
+    pjsua_call_send_dtmf_param_default(&param);
+    param.digits = pj_str((char *) [digits UTF8String]);
+    param.method = PJSUA_DTMF_METHOD_SIP_INFO;
+    pjsua_call_send_dtmf(self.id, &param);
 }
 
 #pragma mark - Callback methods


### PR DESCRIPTION
PJSIP does not support RFC 2833-style DTMF for non-8000 Hz codecs such as OPUS/48000.

It seems that SIP INFO is the recommended method for PJSIP: https://www.spinics.net/lists/pjsip/msg19911.html

SIP INFO should work fine. This is what we use with JSSIP in Juno.
