### PR TITLE
Expose handleIpChange

### DIFF
--- a/ios/RTCPjSip/PjSipEndpoint.h
+++ b/ios/RTCPjSip/PjSipEndpoint.h
@@ -25,6 +25,7 @@
 -(PjSipAccount *)createAccount:(NSDictionary*) config;
 -(void) deleteAccount:(int) accountId;
 -(PjSipAccount *)findAccount:(int)accountId;
+-(void)handleIpChange;
 -(PjSipCall *)makeCall:(PjSipAccount *) account destination:(NSString *)destination callSettings: (NSDictionary *)callSettings msgData: (NSDictionary *)msgData;
 -(void)pauseParallelCalls:(PjSipCall*) call; // TODO: Remove this feature.
 -(PjSipCall *)findCall:(int)callId;

--- a/ios/RTCPjSip/PjSipEndpoint.m
+++ b/ios/RTCPjSip/PjSipEndpoint.m
@@ -210,6 +210,12 @@
     return self.accounts[@(accountId)];
 }
 
+- (void) handleIpChange {
+    pjsua_ip_change_param param;
+    pjsua_ip_change_param_default(&param);
+    pjsua_handle_ip_change(&param);
+}
+
 
 #pragma mark Calls
 

--- a/ios/RTCPjSip/PjSipModule.m
+++ b/ios/RTCPjSip/PjSipModule.m
@@ -50,8 +50,8 @@ RCT_EXPORT_METHOD(createAccount: (NSDictionary *) config resolver:(RCTPromiseRes
     resolve([account toJsonDictionary]);
 }
 
-RCT_EXPORT_METHOD(deleteAccount: (int) accountId resolver:(RCTPromiseResolveBlock) resolve rejecter: (RCTPromiseRejectBlock) reject) {
-    [[PjSipEndpoint instance] deleteAccount:accountId];
+RCT_EXPORT_METHOD(handleIpChange:(RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock) reject) {
+    [[PjSipEndpoint instance] handleIpChange];
     
     resolve(@TRUE);
 }
@@ -70,6 +70,12 @@ RCT_EXPORT_METHOD(registerAccount: (int) accountId renew:(BOOL) renew resolver:(
 
         reject(e.name, e.reason, error);
     }
+}
+
+RCT_EXPORT_METHOD(deleteAccount: (int) accountId resolver:(RCTPromiseResolveBlock) resolve rejecter: (RCTPromiseRejectBlock) reject) {
+    [[PjSipEndpoint instance] deleteAccount:accountId];
+    
+    resolve(@TRUE);
 }
 
 #pragma mark - Call Actions

--- a/src/Endpoint.js
+++ b/src/Endpoint.js
@@ -182,6 +182,10 @@ export default class Endpoint extends EventEmitter {
       return NativeModules.PjSipModule.deleteAccount(account.getId())
     }
 
+    handleIpChange() {
+      return NativeModules.PjSipModule.handleIpChange()
+    }
+
     /**
      * Make an outgoing call to the specified URI.
      * Available call settings:


### PR DESCRIPTION
When moving from wifi to mobile data, PJSIP needs to update its internal network state.

Steps to reproduce:
1. Make call from wifi
2. Disable wifi
3. Make call from 3G

The last call attempt will fail. The SIP REGISTER never reaches the server.
