### PR TITLE
Allow resetting PJSIP

### DIFF
--- a/ios/RTCPjSip/PjSipEndpoint.h
+++ b/ios/RTCPjSip/PjSipEndpoint.h
@@ -20,6 +20,8 @@
 
 -(NSDictionary *)start: (NSDictionary *) config;
 
+-(void) reset;
+
 -(void) updateStunServers: (int) accountId stunServerList:(NSArray *)stunServerList;
 
 -(PjSipAccount *)createAccount:(NSDictionary*) config;

--- a/ios/RTCPjSip/PjSipEndpoint.m
+++ b/ios/RTCPjSip/PjSipEndpoint.m
@@ -146,6 +146,12 @@
     return self;
 }
 
+- (void) reset {
+    pjsua_destroy();
+
+    [self init];
+}
+
 - (NSDictionary *)start: (NSDictionary *)config {
     NSMutableArray *accountsResult = [[NSMutableArray alloc] initWithCapacity:[@([self.accounts count]) unsignedIntegerValue]];
     NSMutableArray *callsResult = [[NSMutableArray alloc] initWithCapacity:[@([self.calls count]) unsignedIntegerValue]];

--- a/ios/RTCPjSip/PjSipModule.m
+++ b/ios/RTCPjSip/PjSipModule.m
@@ -36,6 +36,12 @@ RCT_EXPORT_METHOD(start: (NSDictionary *) config resolver:(RCTPromiseResolveBloc
     resolve(result);
 }
 
+RCT_EXPORT_METHOD(reset:(RCTPromiseResolveBlock) resolve rejecter: (RCTPromiseRejectBlock) reject) {
+    [[PjSipEndpoint instance] reset];
+    
+    resolve(@TRUE);
+}
+
 RCT_EXPORT_METHOD(updateStunServers: (int) accountId stunServerList:(NSArray *) stunServerList resolver:(RCTPromiseResolveBlock) resolve rejecter: (RCTPromiseRejectBlock) reject) {
     [[PjSipEndpoint instance] updateStunServers:accountId stunServerList:stunServerList];
     

--- a/src/Endpoint.js
+++ b/src/Endpoint.js
@@ -101,6 +101,10 @@ export default class Endpoint extends EventEmitter {
         })
     }
 
+    reset() {
+      return NativeModules.PjSipModule.reset()
+    }
+
     updateStunServers(accountId, stunServerList) {
         return new Promise(function(resolve, reject) {
             NativeModules.PjSipModule.updateStunServers(accountId, stunServerList, (successful, data) => {


### PR DESCRIPTION
It seems that `handleIpChange` (added in #4) is not always enough.

Let's try to restart everything as recommended here:
https://trac.pjsip.org/repos/wiki/IPAddressChange#Approach1:Restarteverything

Does this leak? 🤷‍♂️ Not too much. I hope. 