### PR TITLE
Hardcode STUN server

### DIFF
--- a/ios/RTCPjSip/PjSipEndpoint.m
+++ b/ios/RTCPjSip/PjSipEndpoint.m
@@ -41,6 +41,9 @@
         pjsua_config cfg;
         pjsua_config_default(&cfg);
 
+        cfg.stun_srv[0] = pj_str("stun.l.google.com:19302");
+        cfg.stun_srv_cnt = 1;
+
         // cfg.cb.on_reg_state = [self performSelector:@selector(onRegState:) withObject: o];
         cfg.cb.on_reg_state = &onRegStateChanged;
         cfg.cb.on_incoming_call = &onCallReceived;


### PR DESCRIPTION
Without STUN, the client sends an SDP with only a private IP address.

Example SDP retrieved from freeswitch.log (notice to the private address, 10.10.20.107):
```
2019-04-05 09:47:56.660996 [DEBUG] sofia.c:7301 Remote SDP:
v=0
o=- 3763446176 3763446178 IN IP4 10.10.20.107
s=pjmedia
b=AS:117
t=0 0
a=X-nat:0
m=audio 4000 RTP/SAVP 102
c=IN IP4 10.10.20.107
b=TIAS:96000
a=rtpmap:102 opus/48000/2
a=fmtp:102 useinbandfec=1
a=rtcp:4001 IN IP4 10.10.20.107
a=ssrc:1557309083 cname:2c8196a76fc9c4c4
a=crypto:5 AES_CM_128_HMAC_SHA1_80 inline:aCxIVu7MpPfCexbpuA2JN3pVIOQEMq+/c0nIWKQ2
```

It somehow works anyway, at least most of the time 🤷‍♂️ I assume FreeSwitch falls back to the remote IP address on the SIP connection. However, I suspect this is error prone, e.g. if the provided IP address matches an existing IP address on our internal Amazon network/VPN.

We should use ICE for IP address discovery, like we do for web call.

One difference from web call is that we use Amazon ELB for the websocket connection, so FreeSwitch does not see the client's IP address and cannot use that for fallback. For app call we use Amazon NLB which is more transparent.

Simply specifying a STUN server will make PJSIP use it.

Apparently `Endpoint.updateStunServers` is broken (or I don't understand how to use it). If I supply an array of strings, the app crashes with a red screen: [Malformed calls from JS: field sizes are different](https://www.google.dk/search?hl=dk&q=%22Malformed+calls+from+JS%3A+field+sizes+are+different%22).

Let's hardcode a STUN server for now. This is not pretty, but it'll do for now. Someone who is more familiar with Objective-C can clean this up later.